### PR TITLE
Adds encoding for Control|Shift modified keys

### DIFF
--- a/keys.yml
+++ b/keys.yml
@@ -16,35 +16,35 @@ key_bindings:
 
   - { key: Return, mods: Control, chars: "\x1b[13;5u" }
   - { key: Slash, mods: Control, chars: "\x1b[47;5u" }
-  - { key: 51, mods: Control|Shift, chars: "\x1b[60;5u" } # Less
-  - { key: 52, mods: Control|Shift, chars: "\x1b[62;5u" } # Greater
+  - { key: 51, mods: Control|Shift, chars: "\x1b[60;6u" } # Less
+  - { key: 52, mods: Control|Shift, chars: "\x1b[62;6u" } # Greater
 
-  - { key: A, mods: Control|Shift, chars: "\x1b[65;5u" }
-  # - { key: B, mods: Control|Shift, chars: "\x1b[66;5u" }
-  # - { key: C, mods: Control|Shift, chars: "\x1b[67;5u" }
-  - { key: D, mods: Control|Shift, chars: "\x1b[68;5u" }
-  - { key: E, mods: Control|Shift, chars: "\x1b[69;5u" }
-  # - { key: F, mods: Control|Shift, chars: "\x1b[70;5u" }
-  - { key: G, mods: Control|Shift, chars: "\x1b[71;5u" }
-  - { key: H, mods: Control|Shift, chars: "\x1b[72;5u" }
-  - { key: I, mods: Control|Shift, chars: "\x1b[73;5u" }
-  - { key: J, mods: Control|Shift, chars: "\x1b[74;5u" }
-  - { key: K, mods: Control|Shift, chars: "\x1b[75;5u" }
-  - { key: L, mods: Control|Shift, chars: "\x1b[76;5u" }
-  - { key: M, mods: Control|Shift, chars: "\x1b[77;5u" }
-  - { key: N, mods: Control|Shift, chars: "\x1b[78;5u" }
-  - { key: O, mods: Control|Shift, chars: "\x1b[79;5u" }
-  - { key: P, mods: Control|Shift, chars: "\x1b[80;5u" }
-  - { key: Q, mods: Control|Shift, chars: "\x1b[81;5u" }
-  - { key: R, mods: Control|Shift, chars: "\x1b[82;5u" }
-  - { key: S, mods: Control|Shift, chars: "\x1b[83;5u" }
-  - { key: T, mods: Control|Shift, chars: "\x1b[84;5u" }
-  - { key: U, mods: Control|Shift, chars: "\x1b[85;5u" }
-  # - { key: V, mods: Control|Shift, chars: "\x1b[86;5u" }
-  - { key: W, mods: Control|Shift, chars: "\x1b[87;5u" }
-  - { key: X, mods: Control|Shift, chars: "\x1b[88;5u" }
-  - { key: Y, mods: Control|Shift, chars: "\x1b[89;5u" }
-  - { key: Z, mods: Control|Shift, chars: "\x1b[90;5u" }
+  - { key: A, mods: Control|Shift, chars: "\x1b[65;6u" }
+  # - { key: B, mods: Control|Shift, chars: "\x1b[66;6u" }
+  # - { key: C, mods: Control|Shift, chars: "\x1b[67;6u" }
+  - { key: D, mods: Control|Shift, chars: "\x1b[68;6u" }
+  - { key: E, mods: Control|Shift, chars: "\x1b[69;6u" }
+  # - { key: F, mods: Control|Shift, chars: "\x1b[70;6u" }
+  - { key: G, mods: Control|Shift, chars: "\x1b[71;6u" }
+  - { key: H, mods: Control|Shift, chars: "\x1b[72;6u" }
+  - { key: I, mods: Control|Shift, chars: "\x1b[73;6u" }
+  - { key: J, mods: Control|Shift, chars: "\x1b[74;6u" }
+  - { key: K, mods: Control|Shift, chars: "\x1b[75;6u" }
+  - { key: L, mods: Control|Shift, chars: "\x1b[76;6u" }
+  - { key: M, mods: Control|Shift, chars: "\x1b[77;6u" }
+  - { key: N, mods: Control|Shift, chars: "\x1b[78;6u" }
+  - { key: O, mods: Control|Shift, chars: "\x1b[79;6u" }
+  - { key: P, mods: Control|Shift, chars: "\x1b[80;6u" }
+  - { key: Q, mods: Control|Shift, chars: "\x1b[81;6u" }
+  - { key: R, mods: Control|Shift, chars: "\x1b[82;6u" }
+  - { key: S, mods: Control|Shift, chars: "\x1b[83;6u" }
+  - { key: T, mods: Control|Shift, chars: "\x1b[84;6u" }
+  - { key: U, mods: Control|Shift, chars: "\x1b[85;6u" }
+  # - { key: V, mods: Control|Shift, chars: "\x1b[86;6u" }
+  - { key: W, mods: Control|Shift, chars: "\x1b[87;6u" }
+  - { key: X, mods: Control|Shift, chars: "\x1b[88;6u" }
+  - { key: Y, mods: Control|Shift, chars: "\x1b[89;6u" }
+  - { key: Z, mods: Control|Shift, chars: "\x1b[90;6u" }
 
   # - { key: Key0, mods: Control, chars: "\x1b[48;5u" }
   - { key: Key1, mods: Control, chars: "\x1b[49;5u" }


### PR DESCRIPTION
From http://www.leonerd.org.uk/hacks/fixterms/ Control|Shift modified keys should be `CSI ...;6 u`.