### PR TITLE
Adds `<C-/>` keybinding.

### DIFF
--- a/keys.yml
+++ b/keys.yml
@@ -18,6 +18,7 @@ key_bindings:
   # Control + <key> ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
 
   - { key: Return, mods: Control, chars: "\x1b[13;5u" }
+  - { key: Slash,  mods: Control, chars: "\x1b[47;5u" }
 
   # Control + <letter> ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
 


### PR DESCRIPTION
This pull request allows Alacritty to distinguish between `<C-/>` and `<C-_>`.